### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Note: This package is being phased out.
 
-The same functionality is available with [CuArrays](https://github.com/JuliaGPU/CuArrays.jl).
+The same functionality is available with [CUDA.jl](https://github.com/JuliaGPU/CUDA.jl).
 
 # CUDNN
 


### PR DESCRIPTION
CuArrays is deprecated and points to CUDA.jl now. So better to just point there directly.